### PR TITLE
Fix CI Workflow for Building the Toolchain

### DIFF
--- a/.github/workflows/dusk.yml
+++ b/.github/workflows/dusk.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 16
+          fetch-depth: 0
 
       - name: Setup dependencies
         if: matrix.os == 'ubuntu-latest'
@@ -41,15 +41,33 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: |
           brew install ninja gettext &&
-          brew link --force gettext
+          brew link --force gettext &&
+          brew install llvm
 
+      - name: Change cc and ar to wasm-supported versions
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          LLVM_PATH=$(brew --prefix llvm)
+          echo "
+          [target.wasm32-unknown-unknown]
+          cc = \"$LLVM_PATH/bin/clang\"
+          ar = \"$LLVM_PATH/bin/llvm-ar\"
+
+          [target.wasm64-unknown-unknown]
+          cc = \"$LLVM_PATH/bin/clang\"
+          ar = \"$LLVM_PATH/bin/llvm-ar\"
+          " >> config.template.toml
+          
       - name: Generate configuration
         run: |
           HOST=${{ matrix.target }} envsubst < config.template.toml > config.toml &&
           cat config.toml
 
       - name: Run build
-        run: ./x.py dist
+
+        run: |
+          git remote add upstream https://github.com/rust-lang/rust.git
+          ./x.py dist
 
       - name: Set artifact name
         id: artifact-name


### PR DESCRIPTION
For https://github.com/dusk-network/rust/issues/16.

There are three problems with the current CI workflow for building the toolchain:
- Changes made in the compiler's bootstrapping code require a git remote that points to rust-lang/rust present in CI builds.
- Only 16 commits are fetched. This is a problem because, in the compiler's bootstrap code, getting the right version of LLVM requires a retrieval of a git SHA, and getting this SHA requires a retrieval of the merge-base of the local rust repo and the upstream rust repo. The merge-base could be arbitrarily far in the git history, requiring a need to fetch the entire history.
- The default C compiler toolchain on macOS doesn't have a wasm target.

This PR resolves these problems by adding code to:
- Add a git remote that points to rust-lang/rust.
- Fetch the entire git history instead of just 16 commits.
- Install LLVM and use its `clang` and `ar` to compile on macOS instead of the default tools.